### PR TITLE
Update GitHub Actions for Maturin releases

### DIFF
--- a/.github/workflows/maturin-publish.yml
+++ b/.github/workflows/maturin-publish.yml
@@ -1,9 +1,9 @@
 name: Maturin Build
 
 on:
-  push:
-    branches:
-      - publish-to-pypi
+  release:
+    types:
+      - published
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/maturin-publish.yml
+++ b/.github/workflows/maturin-publish.yml
@@ -137,7 +137,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [ manylinux ]
+    needs: [ manylinux, musllinux, windows, macos, sdist ]
     environment: release
     permissions:
       id-token: write

--- a/.github/workflows/maturin-publish.yml
+++ b/.github/workflows/maturin-publish.yml
@@ -1,4 +1,4 @@
-name: Maturin Build
+name: Maturin Publish
 
 on:
   release:

--- a/.github/workflows/maturin-publish.yml
+++ b/.github/workflows/maturin-publish.yml
@@ -3,9 +3,7 @@ name: Maturin Build
 on:
   push:
     branches:
-      - main
       - publish-to-pypi
-  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -19,11 +17,14 @@ jobs:
       matrix:
         target:
           - aarch64
+          - armv7
+          - x86_64
+          - x86
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.13
+          python-version: 3.x
       - name: Install maturin and zig
         run: pip install maturin[zig]
       - name: Build wheels
@@ -39,17 +40,108 @@ jobs:
           name: wheels-manylinux-${{ matrix.target }}
           path: dist
 
+  musllinux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64
+          - armv7
+          - x86_64
+          - x86
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --find-interpreter
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          manylinux: musllinux_1_2
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-musllinux-${{ matrix.target }}
+          path: dist
+
+  windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x64
+          - x86
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+          architecture: ${{ matrix.target }}
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --find-interpreter
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-windows-${{ matrix.target }}
+          path: dist
+
+  macos:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64
+          - x86_64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --find-interpreter
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.target }}
+          path: dist
+
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: dist
+
   release:
     name: Release
     runs-on: ubuntu-latest
     needs: [ manylinux ]
     environment: release
     permissions:
-      # Use to sign the release artefacts
       id-token: write
-      # Used to upload release artefacts
       contents: write
-      # Used to generate artefact attestation
       attestations: write
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/maturin-publish.yml
+++ b/.github/workflows/maturin-publish.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: 3.13
       - name: Install maturin and zig
         run: pip install maturin[zig]
       - name: Build wheels
@@ -59,6 +59,8 @@ jobs:
           subject-path: 'wheels-*/*'
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*

--- a/.github/workflows/maturin-publish.yml
+++ b/.github/workflows/maturin-publish.yml
@@ -1,0 +1,64 @@
+name: Maturin Build
+
+on:
+  push:
+    branches:
+      - main
+      - publish-to-pypi
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  manylinux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - aarch64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Install maturin and zig
+        run: pip install maturin[zig]
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist --find-interpreter --zig
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          manylinux: auto
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-manylinux-${{ matrix.target }}
+          path: dist
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [ manylinux ]
+    environment: release
+    permissions:
+      # Use to sign the release artefacts
+      id-token: write
+      # Used to upload release artefacts
+      contents: write
+      # Used to generate artefact attestation
+      attestations: write
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: 'wheels-*/*'
+      - name: Publish to PyPI
+        uses: PyO3/maturin-action@v1
+        with:
+          command: upload
+          args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
### Description

This pull request adds a new GitHub Actions workflow to build python wheels and publish to PyPI. Key changes include:

- Trigger workflow on release publication.
- Add build support for manylinux, musllinux, macOS, and Windows.
- Introduce `sdist` builds for source distributions.
- Set dependencies for release jobs to ensure all relevant artifacts are generated.
- Add `MATURIN_PYPI_TOKEN` environment secret for secure publishing to PyPI.